### PR TITLE
Expand usage section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,37 @@
 # LiveViewNativeLiveForm
 
+## About
+
 Supporting library for [LiveViewNative SwiftUI](https://github.com/liveviewnative/liveview-client-swiftui) that provides forms that group multiple pieces of data together and allow them to be submitted in a single event.
 
-To use this, add the package to your project and then include the registry in your app's aggregate registry:
-```swift
-struct AppRegistries: AggregateRegistry {
-    typealias Registries = Registry2<
-        MyRegistry,
-        LiveFormRegistry<Self>
-    >
-}
-```
-And then use that registry when creating the `LiveSessionCoordinator`:
-```swift
+
+## Usage
+
+Add this library as a package to your LiveView Native application's Xcode project using its repo URL. Then, create an `AggregateRegistry` to include the provided `LiveFormRegistry` within your native app builds:
+
+```diff
+import SwiftUI
+import LiveViewNative
++ import LiveViewNativeLiveForm
++
++ struct MyRegistry: CustomRegistry {
++     typealias Root = AppRegistries
++ }
++
++ struct AppRegistries: AggregateRegistry {
++     typealias Registries = Registry2<
++         MyRegistry,
++         LiveFormRegistry<Self>
++     >
++ }
+
+@MainActor
 struct ContentView: View {
-    @State private var session = LiveSessionCoordinator<AppRegistries>(url: URL(string: "...")!)
-    // ...
+-     @StateObject private var session = LiveSessionCoordinator(URL(string: "http://localhost:4000/")!)
++     @StateObject private var session = LiveSessionCoordinator<AppRegistries>(URL(string: "http://localhost:4000/")!)
+
+    var body: some View {
+        LiveView(session: session)
+    }
 }
 ```


### PR DESCRIPTION
I found the usage info a little difficult to follow. However, [liveview-native-swiftui-avkit](https://github.com/liveview-native/liveview-native-swiftui-avkit)'s `README.md` was much easier for me to understand. I've updated the `README.md` to be more like `liveview-native-swiftui-avkit`.