### PR TITLE
Add support for `action`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/liveviewnative/liveview-client-swiftui.git", from: "0.2.0"),
+        .package(url: "https://github.com/liveviewnative/liveview-client-swiftui.git", branch: "main"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/swiftui/Sources/LiveViewNativeLiveForm/LiveForm.swift
+++ b/swiftui/Sources/LiveViewNativeLiveForm/LiveForm.swift
@@ -49,7 +49,6 @@ struct LiveForm<R: RootRegistry>: View {
                 guard $0 else { return }
                 submitForm()
             }
-            .id(element.attributeValue(for: "id"))
     }
     
     private func submitForm() {

--- a/swiftui/Sources/LiveViewNativeLiveForm/LiveForm.swift
+++ b/swiftui/Sources/LiveViewNativeLiveForm/LiveForm.swift
@@ -41,9 +41,11 @@ struct LiveForm<R: RootRegistry>: View {
             .task {
                 formModel.pushEventImpl = context.coordinator.pushEvent
                 formModel.updateFromElement(element, submitAction: submitForm)
+                updateHiddenFields()
             }
             .onReceive($element) {
                 formModel.updateFromElement(element, submitAction: submitForm)
+                updateHiddenFields()
             }
             .onChange(of: element.attributeBoolean(for: "phx-trigger-action")) {
                 guard $0 else { return }
@@ -61,6 +63,18 @@ struct LiveForm<R: RootRegistry>: View {
                 httpMethod: method,
                 httpBody: body.data(using: .utf8)
             )
+        }
+    }
+    
+    /// Collects all ``LiveHiddenField`` elements, and sets their values into the form model.
+    private func updateHiddenFields() {
+        for child in element.depthFirstChildren() {
+            guard case let .element(element) = child.data,
+                  element.tag == "LiveHiddenField",
+                  let name = element.attributes.first(where: { $0.name == "name" })?.value,
+                  let value = element.attributes.first(where: { $0.name == "value" })?.value
+            else { continue }
+            self.formModel[name] = value
         }
     }
 }

--- a/swiftui/Sources/LiveViewNativeLiveForm/LiveFormRegistry.swift
+++ b/swiftui/Sources/LiveViewNativeLiveForm/LiveFormRegistry.swift
@@ -27,6 +27,7 @@ public struct LiveFormRegistry<Root: RootRegistry>: CustomRegistry {
     public enum TagName: String {
         case liveForm = "LiveForm"
         case liveSubmitButton = "LiveSubmitButton"
+        case liveHiddenField = "LiveHiddenField"
     }
     
     public static func lookup(_ name: TagName, element: ElementNode) -> some View {
@@ -35,6 +36,8 @@ public struct LiveFormRegistry<Root: RootRegistry>: CustomRegistry {
             LiveForm<Root>()
         case .liveSubmitButton:
             LiveSubmitButton<Root>()
+        case .liveHiddenField:
+            LiveHiddenField()
         }
     }
 }

--- a/swiftui/Sources/LiveViewNativeLiveForm/LiveHiddenField.swift
+++ b/swiftui/Sources/LiveViewNativeLiveForm/LiveHiddenField.swift
@@ -1,0 +1,22 @@
+//
+//  LiveHiddenField.swift
+//  LiveViewNativeLiveForm
+//
+//  Created by Carson.Katri on 3/21/24.
+//
+
+import SwiftUI
+import LiveViewNative
+
+/// An element that has no visible UI, but provides a value to be sent along with the form.
+///
+/// This is equivalent to `<input type="hidden" />` in HTML.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct LiveHiddenField: View {
+    public var body: some View {
+        // logic is handled within `LiveForm`.
+        EmptyView()
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/liveview-native/liveview-client-swiftui/pull/1295

Adds support for the `action`, `method`, and `phx-trigger-action` attributes.