### PR TITLE
fix: Lazy fetch id from form_for

### DIFF
--- a/elixir/lib/live_view_native/live_form/component.ex
+++ b/elixir/lib/live_view_native/live_form/component.ex
@@ -113,7 +113,7 @@ defmodule LiveViewNative.LiveForm.Component do
         {true, attrs} -> Keyword.put(attrs, :enctype, "multipart/form-data")
       end
 
-    attrs = Keyword.put(attrs, :id, Map.get(assigns.rest, :id, form_for.id))
+    attrs = Keyword.put(attrs, :id, Map.get_lazy(assigns.rest, :id, fn -> form_for.id end))
 
     assigns =
       assign(assigns,


### PR DESCRIPTION
When using changesets in the form's "for", we'd get an error because Changeset has no key :id, even if we passed an id to the form component.